### PR TITLE
Default lifetime issue

### DIFF
--- a/Adapter/AbstractAdapter.php
+++ b/Adapter/AbstractAdapter.php
@@ -42,6 +42,9 @@ abstract class AbstractAdapter implements AdapterInterface, LoggerAwareInterface
                 $item->value = $value;
                 $item->isHit = $isHit;
                 $item->defaultLifetime = $defaultLifetime;
+		
+		if ($defaultLifetime>0)
+		    $item->expiry = time() + $defaultLifetime;
 
                 return $item;
             },

--- a/Adapter/ArrayAdapter.php
+++ b/Adapter/ArrayAdapter.php
@@ -42,6 +42,9 @@ class ArrayAdapter implements AdapterInterface, LoggerAwareInterface
                 $item->value = $value;
                 $item->isHit = $isHit;
                 $item->defaultLifetime = $defaultLifetime;
+		
+		if ($defaultLifetime>0)
+		    $item->expiry = time() + $defaultLifetime;
 
                 return $item;
             },

--- a/Tests/Adapter/ApcuAdapterDefaultTimeTest.php
+++ b/Tests/Adapter/ApcuAdapterDefaultTimeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Ernesto Cánovas <ernesto.canovas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+
+
+class ApcuAdapterDefaultTimeTest extends CachePoolTest
+{
+    public function createCachePool()
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->skippedTests['testDeferredSaveWithoutCommit'] = 'Fails on HHVM';
+        }
+
+        if (!function_exists('apcu_fetch') || !ini_get('apc.enabled') || ('cli' === PHP_SAPI && !ini_get('apc.enable_cli'))) {
+            $this->markTestSkipped('APCu extension is required.');
+        }
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Fails transiently on Windows.');
+        }
+
+        return new ApcuAdapter(str_replace('\\', '.', __CLASS__),5);
+    }
+    
+    public function testDefaultTime()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+	
+        $this->cache = $this->createCachePool();
+
+        $item = $this->cache->getItem('key.dlt');
+        $item->set('value');
+        $this->cache->save($item);
+	sleep(2);
+
+	$item = $this->cache->getItem('key.dlt');
+        $this->assertTrue($item->isHit());
+	
+        sleep(6);
+        $item2 = $this->cache->getItem('key.dlt');
+        $this->assertFalse($item2->isHit());
+    }
+}

--- a/Tests/Adapter/ArrayAdapterDefaultTimeTest.php
+++ b/Tests/Adapter/ArrayAdapterDefaultTimeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Ernesto Cánovas <ernesto.canovas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Tests\Adapter\ArrayAdapterTest;
+
+class ArrayAdapterDefaultTimeTest extends ArrayAdapterTest
+{
+
+    public function createCachePool()
+    {
+        return new ArrayAdapter(5);
+    }
+
+    public function testDefaultTime()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+	
+        $this->cache = $this->createCachePool();
+
+        $item = $this->cache->getItem('key.dlt');
+        $item->set('value');
+        $this->cache->save($item);
+	sleep(2);
+
+	$item = $this->cache->getItem('key.dlt');
+        $this->assertTrue($item->isHit());
+	
+        sleep(6);
+        $item2 = $this->cache->getItem('key.dlt');
+        $this->assertFalse($item2->isHit());
+    }
+
+
+}

--- a/Tests/Adapter/FilesystemAdapterDefaultTimeTest.php
+++ b/Tests/Adapter/FilesystemAdapterDefaultTimeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Ernesto Cánovas <ernesto.canovas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Tests\Adapter\FilesystemAdapterTest;
+
+class FilesystemAdapterDefaultTimeTest extends FilesystemAdapterTest
+{
+
+    public function createCachePool()
+    {
+        if (defined('HHVM_VERSION')) {
+            $this->skippedTests['testDeferredSaveWithoutCommit'] = 'Fails on HHVM';
+        }
+        return new FilesystemAdapter('sf-cache',5);
+    }
+    
+    public function testDefaultTime()
+    {
+        if (isset($this->skippedTests[__FUNCTION__])) {
+            $this->markTestSkipped($this->skippedTests[__FUNCTION__]);
+
+            return;
+        }
+	
+        $this->cache = $this->createCachePool();
+
+        $item = $this->cache->getItem('key.dlt');
+        $item->set('value');
+        $this->cache->save($item);
+	sleep(2);
+
+	$item = $this->cache->getItem('key.dlt');
+        $this->assertTrue($item->isHit());
+	
+        sleep(6);
+        $item2 = $this->cache->getItem('key.dlt');
+        $this->assertFalse($item2->isHit());
+    }
+}


### PR DESCRIPTION
[cache component] DefaultLifetime for FilesystemAdapter, ApcuAdapter and ArrayAdapter wasn't working properly.

When It's  used one of the specified Adapters with a defaultLifetime != 0, cacheItem doesn't expire at anytime.

Tests have been added to check this and code to fix it.