### PR TITLE
Always pass $key to NullAdapter->createCacheItem

### DIFF
--- a/Adapter/NullAdapter.php
+++ b/Adapter/NullAdapter.php
@@ -42,7 +42,7 @@ class NullAdapter implements AdapterInterface, CacheInterface
      */
     public function get(string $key, callable $callback, float $beta = null, array &$metadata = null)
     {
-        return $callback(($this->createCacheItem)());
+        return $callback(($this->createCacheItem)($key));
     }
 
     /**


### PR DESCRIPTION
Previously, if this were called, it would throw an ArgumentCountError.
I'm assuming existing code always checks hasItem, so this bug hasn't impacted many people.
This was noticed via static analysis.