### PR TITLE
Fixed cache pools affecting each other due to an overwritten seed variable

### DIFF
--- a/DependencyInjection/CachePoolPass.php
+++ b/DependencyInjection/CachePoolPass.php
@@ -79,11 +79,11 @@ class CachePoolPass implements CompilerPassInterface
             }
             $name = $tags[0]['name'] ?? $id;
             if (!isset($tags[0]['namespace'])) {
+                $namespaceSeed = $seed;
                 if (null !== $class) {
-                    $seed .= '.'.$class;
+                    $namespaceSeed .= '.'.$class;
                 }
-
-                $tags[0]['namespace'] = $this->getNamespace($seed, $name);
+                $tags[0]['namespace'] = $this->getNamespace($namespaceSeed, $name);
             }
             if (isset($tags[0]['clearer'])) {
                 $clearer = $tags[0]['clearer'];


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/33561 for the description of the issue. I was asked to create a PR for it, so here it is.