### PR TITLE
Fixed Redis Sentinel usage when only one Sentinel specified

### DIFF
--- a/Traits/RedisTrait.php
+++ b/Traits/RedisTrait.php
@@ -271,7 +271,7 @@ trait RedisTrait
             if (null !== $auth) {
                 $params['parameters']['password'] = $auth;
             }
-            if (1 === \count($hosts) && !$params['redis_cluster']) {
+            if (1 === \count($hosts) && !($params['redis_cluster'] || $params['redis_sentinel'])) {
                 $hosts = $hosts[0];
             } elseif (\in_array($params['failover'], ['slaves', 'distribute'], true) && !isset($params['replication'])) {
                 $params['replication'] = true;


### PR DESCRIPTION
Fixes #33796 in symfony/symfony

Added check for `$params['redis_sentinel']` to line 274 of `RedisTrait.php`, as with a single Sentinel host (as you might in a test environment) the previous behaviour of converting the array of hosts to a single host configuration caused the class to initialise incorrectly and throw an error when later calling methods specific to the Sentinel interface.