### PR TITLE
Return empty array if maxmemory-policy is not supported

### DIFF
--- a/Adapter/RedisTagAwareAdapter.php
+++ b/Adapter/RedisTagAwareAdapter.php
@@ -97,7 +97,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
         if ('noeviction' !== $eviction && 0 !== strpos($eviction, 'volatile-')) {
             CacheItem::log($this->logger, sprintf('Redis maxmemory-policy setting "%s" is *not* supported by RedisTagAwareAdapter, use "noeviction" or  "volatile-*" eviction policies', $eviction));
 
-            return false;
+            return [];
         }
 
         // serialize values


### PR DESCRIPTION
Fix: In case if redis maxmemory-policy is not supported return empty array.