### PR TITLE
Connect to RedisCluster with password auth

### DIFF
--- a/Traits/RedisTrait.php
+++ b/Traits/RedisTrait.php
@@ -228,7 +228,7 @@ trait RedisTrait
                 }
 
                 try {
-                    $redis = new $class(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) $params['persistent']);
+                    $redis = new $class(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) $params['persistent'], $params['auth'] ?? '');
                 } catch (\RedisClusterException $e) {
                     throw new InvalidArgumentException(sprintf('Redis connection "%s" failed: ', $dsn).$e->getMessage());
                 }


### PR DESCRIPTION
Currently it is not possible to connect to RedisCluster with password. AUTH param is described in documentation (last example) https://symfony.com/doc/current/components/cache/adapters/redis_adapter.html#configure-the-connection but totally ignored in the code and connection fails

```
RedisAdapter::createConnection(
    'redis:?host[localhost]&host[localhost:6379]&host[/var/run/redis.sock:]&auth=my-password&redis_cluster=1'
);
```

See RedisCluster usage here https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#declaring-a-cluster-with-an-array-of-seeds