### PR TITLE
phpredis: Added full TLS support for RedisCluster

### DIFF
--- a/Traits/RedisClusterNodeProxy.php
+++ b/Traits/RedisClusterNodeProxy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+/**
+ * This file acts as a wrapper to the RedisCluster implementation
+ *
+ * Calls are made to nodes via RedisCluster->{method}($host, ...args)'
+ *  according to https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#directed-node-commands
+ *
+ * @author Jack Thomas <jack.thomas@solidalpha.com>
+ *
+ * @internal
+ */
+class RedisClusterNodeProxy
+{
+    /** @var array */
+    private $host;
+
+    /** @var RedisClusterProxy|RedisCluster */
+    private $redis;
+
+    /**
+     * @param array $redisHost
+     * @param \RedisCluster|RedisClusterProxy $redis
+     */
+    public function __construct(array $host, $redis)
+    {
+        $this->host = $host;
+        $this->redis = $redis;
+
+        /*
+        Old Implementation:
+        use \Redis;
+
+        $h = new Redis();
+        $h->connect($host[0], $host[1]);
+        */
+    }
+
+    public function __call(string $method, array $args)
+    {
+        return $this->redis->{$method}($this->host, ...$args);
+    }
+}

--- a/Traits/RedisTrait.php
+++ b/Traits/RedisTrait.php
@@ -265,7 +265,7 @@ trait RedisTrait
                 }
 
                 try {
-                    $redis = new $class(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) $params['persistent'], $params['auth'] ?? '');
+                    $redis = new $class(null, $hosts, $params['timeout'], $params['read_timeout'], (bool) $params['persistent'], $params['auth'] ?? '', $params['ssl'] ?? null);
                 } catch (\RedisClusterException $e) {
                     throw new InvalidArgumentException(sprintf('Redis connection "%s" failed: ', $dsn).$e->getMessage());
                 }
@@ -558,8 +558,7 @@ trait RedisTrait
         } elseif ($this->redis instanceof RedisClusterProxy || $this->redis instanceof \RedisCluster) {
             $hosts = [];
             foreach ($this->redis->_masters() as $host) {
-                $hosts[] = $h = new \Redis();
-                $h->connect($host[0], $host[1]);
+                $hosts[] = new RedisClusterNodeProxy($host, $this->redis);
             }
         }
 


### PR DESCRIPTION
This Pr bridges the gap for full TLS support when using phpredis driver implementation of TLS.

Adds the 'ssl' options array for cache configuration when using RedisCluster

Switches directed node commands from using individual \Redis connections to using the recommended implementation from the phpredis documentation:
https://github.com/phpredis/phpredis/blob/develop/cluster.markdown#directed-node-commands