### PR TITLE
Setting an expiry on SETS too

### DIFF
--- a/Adapter/RedisTagAwareAdapter.php
+++ b/Adapter/RedisTagAwareAdapter.php
@@ -110,6 +110,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
             foreach ($addTagData as $tagId => $ids) {
                 if (!$failed || $ids = array_diff($ids, $failed)) {
                     yield 'sAdd' => array_merge([$tagId], $ids);
+                    yield 'expire' => [$tagId, 0 >= $lifetime ? self::DEFAULT_CACHE_TTL : $lifetime,];
                 }
             }
 


### PR DESCRIPTION
As stated in [the code](https://github.com/symfony/cache/blob/5.2/Adapter/RedisTagAwareAdapter.php#L90), the `RedisTagAwareAdapter` requires Eviction policies to be either `volatile-ttl`, `volatile-lru` or `volatile-lfu`. However, in order for volatile eviction methods to work, [the records MUST have an `expiry`](https://redis.io/topics/lru-cache#eviction-policies)

However, for whatever reason an expiry on Sets are missing. It is only set on strings. I guess it was just forgotten

